### PR TITLE
Clock and sun improvements

### DIFF
--- a/Assets/Clock/Scripts/Clock.cs
+++ b/Assets/Clock/Scripts/Clock.cs
@@ -1,5 +1,4 @@
 using UnityEngine;
-using System.Collections;
 
 public class Clock : MonoBehaviour {
 //-----------------------------------------------------------------------------------------------------------------------------------------
@@ -15,6 +14,7 @@ public class Clock : MonoBehaviour {
     //-- set start time 00:00
     public int minutes = 0;
     public int hour = 0;
+    public bool running = true;
 
     //-- time speed factor
     public float clockSpeed = 1.0f;     // 1.0f = realtime, < 1.0f = slower, > 1.0f = faster
@@ -22,6 +22,7 @@ public class Clock : MonoBehaviour {
     //-- internal vars
     int seconds;
     float msecs;
+    bool displaySeconds = true;
     GameObject pointerSeconds;
     GameObject pointerMinutes;
     GameObject pointerHours;
@@ -38,10 +39,14 @@ void Start()
 }
 
 // This was added to be able to reset seconds
-public void Restart()
-{
+public void Restart() {
     msecs = 0.0f;
     seconds = 0;
+}
+
+public void showSeconds (bool show = true) {
+    pointerSeconds.SetActive(show);
+    displaySeconds = show;
 }
 
 //-----------------------------------------------------------------------------------------------------------------------------------------
@@ -49,22 +54,25 @@ public void Restart()
 //-----------------------------------------------------------------------------------------------------------------------------------------
 void Update() 
 {
-    //-- calculate time
-    msecs += Time.deltaTime * clockSpeed;
-    if(msecs >= 1.0f)
-    {
-        msecs -= 1.0f;
-        seconds++;
-        if(seconds >= 60)
+    if (running) {
+        //-- calculate time
+        msecs += Time.deltaTime * clockSpeed;
+        if(msecs >= 1.0f)
         {
-            seconds = 0;
-            minutes++;
-            if(minutes > 60)
+            msecs -= 1.0f;
+            seconds++;
+            if(seconds >= 60)
             {
-                minutes = 0;
-                hour++;
-                if(hour >= 24)
-                    hour = 0;
+                PubSub.publish("clock:minuteProgressed", this);
+                seconds = 0;
+                minutes++;
+                if(minutes > 60)
+                {
+                    minutes = 0;
+                    hour++;
+                    if(hour >= 24)
+                        hour = 0;
+                }
             }
         }
     }
@@ -72,7 +80,7 @@ void Update()
 
     //-- calculate pointer angles
     float rotationSeconds = (360.0f / 60.0f)  * seconds;
-    float rotationMinutes = (360.0f / 60.0f)  * minutes;
+    float rotationMinutes = (360.0f / 60.0f)  * minutes + (displaySeconds ? 0 : ((360.0f / (60.0f * 60.0f)) * seconds));
     float rotationHours   = ((360.0f / 12.0f) * hour) + ((360.0f / (60.0f * 12.0f)) * minutes);
 
     //-- draw pointers

--- a/Assets/Scripts/BriefAndSummaryPopup.cs
+++ b/Assets/Scripts/BriefAndSummaryPopup.cs
@@ -24,6 +24,7 @@ public class BriefAndSummaryPopup : PopupWindowStyles, IPubSub {
 			if (Input.anyKey && level != null) {
 				hide ();
 				Game.instance.freezeGame (false);
+                PubSub.publish("clock:start");
 			}
 		}
 	}

--- a/Assets/Scripts/Level/Level.cs
+++ b/Assets/Scripts/Level/Level.cs
@@ -18,6 +18,8 @@ public class Level {
     public DateTime dateTime;
     public string date;
     public string timeOfDay;
+    public int timeProgressionFactor;
+    public bool timeDisplaySeconds;
     public string country;
     public string mapUrl;
     public string configUrl;
@@ -96,6 +98,14 @@ public class Level {
         date = Misc.xmlString (levelAttributes.GetNamedItem ("date"));
         timeOfDay = Misc.xmlString (levelAttributes.GetNamedItem ("timeOfDay"));
         dateTime = Misc.parseDateTime(date, timeOfDay);
+        timeProgressionFactor = Misc.xmlInt (levelAttributes.GetNamedItem ("timeProgressionFactor"), 1);
+        timeDisplaySeconds = Misc.xmlBool (levelAttributes.GetNamedItem ("timeDisplaySeconds"), true);
+
+        PubSub.publish ("clock:setTime", timeOfDay);
+        PubSub.publish ("clock:setDisplaySeconds", timeDisplaySeconds);
+        PubSub.publish ("clock:setSpeed", timeProgressionFactor);
+        PubSub.publish ("clock:stop");
+
         country = Misc.xmlString (levelAttributes.GetNamedItem ("country"));
         mapUrl = Misc.xmlString (levelAttributes.GetNamedItem ("mapUrl"));
         configUrl = Misc.xmlString (levelAttributes.GetNamedItem ("configUrl"));

--- a/Assets/Scripts/PointAndClock.cs
+++ b/Assets/Scripts/PointAndClock.cs
@@ -10,10 +10,15 @@ public class PointAndClock : MonoBehaviour, IPubSub {
 		// For Clock
 		clock = GetComponentInChildren<Clock> ();
 		PubSub.subscribe ("clock:setTime", this);
+		PubSub.subscribe ("clock:setSpeed", this);
+		PubSub.subscribe ("clock:setDisplaySeconds", this);
+		PubSub.subscribe ("clock:start", this);
+		PubSub.subscribe ("clock:stop", this);
 
 		clock.hour = 0;
 		clock.minutes = 0;
-		clock.clockSpeed = 0f;
+		clock.clockSpeed = 1f;
+        clock.running = false;
 	}
 
 	#region IPubSub implementation
@@ -23,9 +28,16 @@ public class PointAndClock : MonoBehaviour, IPubSub {
 			string[] timeParts = time.Split (':');
 			clock.hour = Convert.ToInt32 (timeParts [0]);
 			clock.minutes = Convert.ToInt32 (timeParts [1]);
-			clock.clockSpeed = 1f;
             clock.Restart();
-		}
+		} else if (message == "clock:setSpeed") {
+            clock.clockSpeed = (int)data;
+        } else if (message == "clock:setDisplaySeconds") {
+            clock.showSeconds((bool)data);
+        } else if (message == "clock:start") {
+            clock.running = true;
+        } else if (message == "clock:stop") {
+            clock.running = false;
+        }
 		return PROPAGATION.DEFAULT;
 	}
 	#endregion

--- a/Assets/Scripts/Utilities/Misc.cs
+++ b/Assets/Scripts/Utilities/Misc.cs
@@ -214,7 +214,7 @@ public class Misc {
 
 	public static bool xmlBool(XmlNode attributeNode, bool defaultValue = false) {
 		string strVal = Misc.xmlString (attributeNode);
-		return strVal == "true" ? true : defaultValue;
+		return strVal == "true" ? true : (strVal == null ? defaultValue : false);
 	}
 
 	public static int xmlInt(XmlNode attributeNode, int defaultValue = 0) {


### PR DESCRIPTION
Extended the clock to be able to hide second pointer and move minute pointer smoother when that’s the case. Also made it notify on each minute change.

Minute changes are now acted upon and sun position and intensity is adjusted on these. Sun calculations was choppy earlier, so also cached a full day of values and smoothed them out. So when a level (clockwise) is sped up, the sun will move quite nicely (limited levels to 24hrs clock time)